### PR TITLE
Keep the documentation link up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ generated sources in the specified source set. Multiple configurations are suppo
 participate in the Gradle uptodate checks.
 
 You can find out more details about the actual jOOQ source code generation in the
-[jOOQ documentation](http://www.jooq.org/doc/3.3/manual/code-generation).
+[jOOQ documentation](http://www.jooq.org/doc/latest/manual/code-generation).
 
 # Plugin
 


### PR DESCRIPTION
This trivial change will help keep the documentation link up to date.

Thanks for this nicely documented contribution. A Gradle plugin is something that many users have been asking for, but we haven't been able to prioritise our efforts towards it, so far. I will happily point them to your implementation in the near future!
