### PR TITLE
Update to the latest jOOQ version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ bintrayPluginVersion = 1.2
 
 # compile/runtime dependency versions
 commonsLangVersion = 2.6
-jooqVersion = 3.6.2
+jooqVersion = 3.8.4


### PR DESCRIPTION
The latest version right now is 3.8.4, but I wonder if there should be any hard wired version here...? Is the user able to override this default?