### PR TITLE
Make plugin independent of Jooq version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,55 +10,64 @@ participate in the Gradle uptodate checks.
 You can find out more details about the actual jOOQ source code generation in the
 [jOOQ documentation](http://www.jooq.org/doc/latest/manual/code-generation).
 
-# Plugin
+The plugin is hosted on the [Gradle Plugin portal](https://plugins.gradle.org/plugin/nu.studer.jooq).
 
-## General
-The jOOQ plugin automatically applies the Java plugin. Thus, there is no need to explicitly apply the Java plugin in
-your build script when using the jOOQ plugin.
+# Applying the plugin
 
-Depending on the type of database that is accessed to derive the jOOQ Java sources, the corresponding driver must
-be put on the plugin classpath.
-
-The jOOQ plugin is hosted at [Bintray's JCenter](https://bintray.com/etienne/gradle-plugins/gradle-jooq-plugin).
-
-## Gradle 1.x and 2.x
-To use the jOOQ plugin with versions of Gradle 1.x and 2.x, apply the plugin in your `build.gradle` script:
+You can apply the plugin using the plugins DSL
 
 ```groovy
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'nu.studer:gradle-jooq-plugin:1.0.5'
-        classpath 'postgresql:postgresql:9.1-901.jdbc4' // database-specific JDBC driver
-    }
+plugins {
+    id 'nu.studer.jooq' version '1.0.6'
 }
-apply plugin: 'nu.studer.jooq'
 ```
 
-## Custom jOOQ Version
-You can use the jOOQ plugin with any current, previous, or future version of jOOQ. Simply enforce the required version of the jOOQ libraries in your `build.gradle` script:
+Or using the buildscript block
+
 ```groovy
 buildscript {
-    repositories {
-        jcenter()
+  repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
     }
-    dependencies {
-        classpath 'nu.studer:gradle-jooq-plugin:1.0.5'
-        classpath 'postgresql:postgresql:9.1-901.jdbc4' // database-specific JDBC driver
-    }
-    configurations.classpath {
-        resolutionStrategy {                            // enforce a specific jOOQ version
-            forcedModules = [
-                'org.jooq:jooq:3.4.1',
-                'org.jooq:jooq-meta:3.4.1',
-                'org.jooq:jooq-codegen:3.4.1'
-            ]     
-        }
-    }
+  }
+  dependencies {
+    classpath "nu.studer:gradle-jooq-plugin:1.0.6"
+  }
 }
-apply plugin: 'nu.studer.jooq'
+
+apply plugin: "nu.studer.jooq"
+```
+
+# Defining your database drivers
+
+Depending on which database you are connecting to, you'll need to put the corresponding driver on the generator's classpath.
+
+```groovy
+dependencies {
+    jooqGeneratorClasspath 'postgresql:postgresql:9.1-901.jdbc4'
+}
+```
+
+# Specifying the jOOQ version and edition
+
+This plugin supports existing and future jOOQ versions. It also supports the different editions like open source, pro and trial.
+
+```groovy
+jooq {
+  version = '3.8.2' //the default, can be omitted
+  edition = 'OSS'   //the default, can be omitted. Other values are PRO, PRO_JAVA_6 and TRIAL
+}
+```
+
+The plugin will ensure that all your dependencies use the version and edition
+specified in the jooq configuration. So when you declare a compile dependency
+on jOOQ, you can omit the version:
+
+```groovy
+dependencies {
+  compile 'org.jooq:jooq'
+}
 ```
 
 # Tasks
@@ -86,7 +95,7 @@ gradle build -i
 The example below shows a jOOQ configuration that creates the jOOQ Java sources from a PostgreSQL database schema and 
 includes them in the `main` source set.
 
-By default, the generated sources are written to `build/generated-src/jooq/<sourceSet>/<configurationName>`. The 
+By default, the generated sources are written to `build/generated-src/jooq/<configurationName>`. The
 output directory can be configured by explicitly setting the `directory` attribute of the `target` configuration.
 
 See the [jOOQ XSD](http://www.jooq.org/xsd/jooq-codegen-3.3.0.xsd) for the full set of configuration options.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ gradle-jooq-plugin
 ==================
 
 # Overview
-[Gradle](http://www.gradle.org) plugin that integrates [jOOQ](http://www.jooq.org). For each jOOQ configuration declared 
+[Gradle](http://www.gradle.org) plugin that integrates [jOOQ](http://www.jooq.org). For each jOOQ configuration declared
 in the build, the plugin adds a task to generate the jOOQ Java sources from a given database schema and includes the
-generated sources in the specified source set. Multiple configurations are supported. The code generation tasks fully 
+generated sources in the specified source set. Multiple configurations are supported. The code generation tasks fully
 participate in the Gradle uptodate checks.
 
 You can find out more details about the actual jOOQ source code generation in the
@@ -45,7 +45,7 @@ Depending on which database you are connecting to, you'll need to put the corres
 
 ```groovy
 dependencies {
-    jooqGeneratorClasspath 'postgresql:postgresql:9.1-901.jdbc4'
+    jooqRuntime 'postgresql:postgresql:9.1-901.jdbc4'
 }
 ```
 
@@ -71,9 +71,9 @@ dependencies {
 ```
 
 # Tasks
-For each jOOQ configuration declared in the build, the plugin adds a new `generate[ConfigurationName]JooqSchemaSource` 
+For each jOOQ configuration declared in the build, the plugin adds a new `generate[ConfigurationName]JooqSchemaSource`
 task to your project. Each task generates the jOOQ Java sources from the configured database schema and includes these
-sources in the specified source set. For example, a jOOQ configuration named `sample` will cause the plugin to add a 
+sources in the specified source set. For example, a jOOQ configuration named `sample` will cause the plugin to add a
 new code generation task `generateSampleJooqSchemaSource` to the project.
 
 ```console
@@ -92,7 +92,7 @@ gradle build -i
 
 # Configuration
 
-The example below shows a jOOQ configuration that creates the jOOQ Java sources from a PostgreSQL database schema and 
+The example below shows a jOOQ configuration that creates the jOOQ Java sources from a PostgreSQL database schema and
 includes them in the `main` source set.
 
 By default, the generated sources are written to `build/generated-src/jooq/<configurationName>`. The

--- a/build.gradle
+++ b/build.gradle
@@ -43,5 +43,3 @@ bintray {
     pkg.repo = 'gradle-plugins'
     dryRun = true
 }
-
-wrapper.gradleVersion = '1.12'

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ bintrayPluginVersion = 1.2
 
 # compile/runtime dependency versions
 commonsLangVersion = 2.6
-jooqVersion = 3.6.2
+jooqVersion =  3.8.4

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'gradle-jooq-plugin'

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqConfiguration.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqConfiguration.groovy
@@ -15,21 +15,29 @@
  */
 package nu.studer.gradle.jooq
 
-import nu.studer.gradle.util.JaxbConfigurationBridge
+import org.apache.commons.lang.StringUtils
+import org.gradle.api.Named
 import org.gradle.api.tasks.SourceSet
+import org.jooq.util.jaxb.Configuration
 
 /**
  * Represents a jOOQ configuration which consists of the actual jOOQ source code generation configuration and
  * the source set in which to include the generated sources.
  */
-class JooqConfiguration {
+class JooqConfiguration implements Named {
 
+    final String name
     final SourceSet sourceSet
-    final JaxbConfigurationBridge configBridge
+    final Configuration configuration
 
-    JooqConfiguration(SourceSet sourceSet, JaxbConfigurationBridge configBridge) {
+    JooqConfiguration(String name, SourceSet sourceSet, Configuration configuration) {
+        this.name = name
         this.sourceSet = sourceSet
-        this.configBridge = configBridge
+        this.configuration = configuration
+    }
+
+    def getJooqTaskName() {
+        "generate${StringUtils.capitalize(name)}JooqSchemaSource"
     }
 
 }

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqEdition.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqEdition.java
@@ -1,0 +1,23 @@
+package nu.studer.gradle.jooq;
+
+/**
+ * jOOQ comes in different editions, which are published
+ * under different group ids. The artifact names and versions
+ * are the same for all editions.
+ */
+public enum JooqEdition {
+    OSS("org.jooq"),
+    PRO("org.jooq.pro"),
+    PRO_JAVA_6("org.jooq.pro-java-6"),
+    TRIAL("org.jooq.trial");
+
+    String groupId;
+
+    private JooqEdition(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+}

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqExtension.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqExtension.groovy
@@ -16,7 +16,6 @@
 package nu.studer.gradle.jooq
 
 import nu.studer.gradle.util.JaxbConfigurationBridge
-import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSet
 import org.jooq.util.jaxb.Configuration
 
@@ -26,14 +25,12 @@ import org.jooq.util.jaxb.Configuration
  */
 class JooqExtension {
 
-    final Project project
-    final Closure jooqConfigurationHandler
+    final Closure whenConfigAdded
     final String path
     final Map<String, JooqConfiguration> configs
 
-    JooqExtension(Project project, Closure jooqConfigurationHandler, String path) {
-        this.project = project
-        this.jooqConfigurationHandler = jooqConfigurationHandler
+    JooqExtension(Closure jooqConfigurationHandler, String path) {
+        this.whenConfigAdded = jooqConfigurationHandler
         this.path = path
         this.configs = [:]
     }
@@ -57,7 +54,7 @@ class JooqExtension {
         }
 
         // apply the given closure to the configuration bridge, i.e. its contained JAXB Configuration object
-        def delegate = jooqConfig.configBridge
+        def delegate = new JaxbConfigurationBridge(jooqConfig.configuration, "${path}.${configName}")
         Closure copy = (Closure) closure.clone();
         copy.resolveStrategy = Closure.DELEGATE_FIRST;
         copy.delegate = delegate;
@@ -73,14 +70,8 @@ class JooqExtension {
     private JooqConfiguration findOrCreateConfig(String configName, SourceSet sourceSet) {
         JooqConfiguration jooqConfig = configs[configName]
         if (!jooqConfig) {
-            // create jOOQ configuration
-            def configBridge = new JaxbConfigurationBridge(new Configuration(), "${path}.${configName}")
-            jooqConfig = new JooqConfiguration(sourceSet, configBridge)
-
-            // pre-configure jOOQ configuration and create task derived from the configuration
-            jooqConfigurationHandler configName, jooqConfig
-
-            // register jOOQ configuration
+            jooqConfig = new JooqConfiguration(configName, sourceSet, new Configuration())
+            whenConfigAdded(jooqConfig)
             configs[configName] = jooqConfig
         }
         jooqConfig

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqExtension.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqExtension.groovy
@@ -28,6 +28,8 @@ class JooqExtension {
     final Closure whenConfigAdded
     final String path
     final Map<String, JooqConfiguration> configs
+    String version = "3.8.4"
+    JooqEdition edition = JooqEdition.OSS
 
     JooqExtension(Closure jooqConfigurationHandler, String path) {
         this.whenConfigAdded = jooqConfigurationHandler

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqPlugin.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqPlugin.groovy
@@ -34,7 +34,7 @@ class JooqPlugin implements Plugin<Project> {
 
     Project project
     JooqExtension extension
-    Configuration jooqGeneratorClasspath
+    Configuration jooqRuntime
 
     public void apply(Project project) {
         this.project = project
@@ -65,9 +65,9 @@ class JooqPlugin implements Plugin<Project> {
      * Users can add their JDBC drivers or any generator extensions they might have.
      */
     private void addJooqConfiguration(Project project) {
-        jooqGeneratorClasspath = project.configurations.create("jooqGeneratorClasspath")
-        jooqGeneratorClasspath.setDescription("The classpath used to invoke the jOOQ generator. Add your JDBC drivers or generator extensions here.")
-        project.dependencies.add(jooqGeneratorClasspath.name, "org.jooq:jooq-codegen")
+        jooqRuntime = project.configurations.create("jooqRuntime")
+        jooqRuntime.setDescription("The classpath used to invoke the jOOQ generator. Add your JDBC drivers or generator extensions here.")
+        project.dependencies.add(jooqRuntime.name, "org.jooq:jooq-codegen")
     }
 
     /*
@@ -91,7 +91,7 @@ class JooqPlugin implements Plugin<Project> {
         jooqTask.description = "Generates the jOOQ sources from the '$jooqConfiguration.name' jOOQ configuration."
         jooqTask.group = "jOOQ"
         jooqTask.configuration = jooqConfiguration.configuration
-        jooqTask.jooqClasspath = jooqGeneratorClasspath
+        jooqTask.jooqClasspath = jooqRuntime
     }
 
     /*

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqTask.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqTask.groovy
@@ -14,30 +14,34 @@
  limitations under the License.
  */
 package nu.studer.gradle.jooq
+
+import nu.studer.gradle.util.Objects
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.jooq.util.GenerationTool
 import org.jooq.util.jaxb.Configuration
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+
 /**
  * Gradle Task that runs the jOOQ source code generation.
  */
 class JooqTask extends DefaultTask {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(JooqTask.class);
+    def Configuration configuration
 
-    def JooqConfiguration jooqConfiguration
-
-    @SuppressWarnings(["GroovyUnusedDeclaration", "GroovyAssignabilityCheck"])
-    @TaskAction
-    public void generate() {
-        // generate the jOOQ schema sources for the given configuration
-        Configuration config = jooqConfiguration.configBridge.target
-        config.generator.target.directory = project.file(config.generator.target.directory).absolutePath
-        new GenerationTool().run config;
-        LOGGER.debug("Performed jOOQ source code generation.");
-
+    @Input
+    def getConfigHash() {
+        Objects.deepHashCode(configuration)
     }
 
+    @OutputDirectory
+    def getOutputDirectory () {
+        configuration.generator.target.directory
+    }
+
+    @TaskAction
+    public void generate() {
+        new GenerationTool().run(configuration)
+    }
 }


### PR DESCRIPTION
This change allows users to choose their desired jOOQ version and edition on the JooqExtension. It also replaces the in-process execution of jOOQ with a forked execution using a dedicated classpath.

This has many benefits:

- users can use whatever Jooq version they want, independent of which this plugin is compiled against
- users don't need to use `buildscript` workarounds to adjust the version, so they can instead use the much more concise `plugins` DSL
- the plugin integrates with `java-base` instead of `java` now, so it is easier to use for projects/enterprises with their own conventions