### PR TITLE
Upgrade to jOOQ 3.9.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ credentialsPluginVersion = 1.0.3
 
 # compile/runtime dependency versions
 commonsLangVersion = 2.6
-jooqVersion = 3.8.6
+jooqVersion = 3.9.0
 junitVersion=4.12


### PR DESCRIPTION
jOOQ 3.9.0 includes a new code generator configuration option (javaTimeTypes) that is of interest to me.  New generator options aren't available by using ```jooq { version = "3.9.0" }```, so, I'm submitting this tiny patch to switch to the new jOOQ release to allow access to this new option.  I've run a `gradle check` locally & successfully.

Thanks for this awesome Gradle plugin and your continued maintenance of it!