### PR TITLE
Changed some usages of 3.8.5 to 3.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This plugin supports existing and future jOOQ versions. It also supports the dif
 
 ```groovy
 jooq {
-  version = '3.8.5' // the default (can be omitted)
+  version = '3.9.0' // the default (can be omitted)
   edition = 'OSS'   // the default (can be omitted), other allowed values are PRO, PRO_JAVA_6, and TRIAL
 }
 ```
@@ -102,7 +102,7 @@ See the [jOOQ XSD](http://www.jooq.org/xsd/jooq-codegen-3.3.0.xsd) for the full 
 
 ```groovy
 jooq {
-   version = '3.8.5'
+   version = '3.9.0'
    edition = 'OSS'
    sample(sourceSets.main) {
        jdbc {

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqExtension.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqExtension.groovy
@@ -25,7 +25,7 @@ import org.jooq.util.jaxb.Configuration
  */
 class JooqExtension {
 
-    private static final String DEFAULT_JOOQ_VERSION = "3.8.5"
+    private static final String DEFAULT_JOOQ_VERSION = "3.9.0"
     private static final JooqEdition DEFAULT_JOOQ_EDITION = JooqEdition.OSS
 
     final Closure whenConfigAdded


### PR DESCRIPTION
I suspect the version in `JooqExtension` was causing my usage of the plugin to remain with 3.8.5 even though the version attribute has been specified (this could be a whole other issue though).