### PR TITLE
Avoid documenting a deprecated configuration element

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ jooq {
            url = 'jdbc:postgresql://localhost:5432/sample'
            user = 'some_user'
            password = 'secret'
-           schema = 'public'
            properties {
                property {
                    key = 'ssl'


### PR DESCRIPTION
The `/configuration/jdbc/schema` element has been deprecated for a while and shouldn't be documented. People should only use the `/configuration/generator/database/inputSchema` element (as documented), or the more sophisticated schema mapping configuration instead.