### PR TITLE
Use Java serialization for Task input instead of JAXB.

### DIFF
--- a/src/main/groovy/nu/studer/gradle/jooq/JooqTask.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqTask.groovy
@@ -61,9 +61,8 @@ class JooqTask extends DefaultTask {
 
     @Input
     @SuppressWarnings("GroovyUnusedDeclaration")
-    BigInteger getConfigurationHash() {
-        // Gradle does not serialize byte[] in a stable manner, so expose as a stable number
-        new BigInteger(getConfigurationBytes())
+    Configuration getConfigurationHash() {
+        return relativizeTo(configuration, project.projectDir)
     }
 
     @Internal

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqTask.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqTask.groovy
@@ -62,7 +62,7 @@ class JooqTask extends DefaultTask {
     @Input
     @SuppressWarnings("GroovyUnusedDeclaration")
     Configuration getConfigurationHash() {
-        return relativizeTo(configuration, project.projectDir)
+        relativizeTo(configuration, project.projectDir)
     }
 
     @Internal


### PR DESCRIPTION
#76 changed the `JooqTask` input from a hash code to the serialized bytes of the XML configuration since hash code is not stable across JVM versions (someday it may not even be stable across JVM invocations). However, this seems to hit a behavior in Gradle where the Gradle classpath is not ready when doing the serialization (#77), which can prevent e.g., a classpath workaround to allow the plugin to work on JDK9 without any extra command line flags.

Gradle allows any `Serializable` object to be used as a task input, which `Configuration` is, so there doesn't seem to be a big reason to use the special JAXB marshalling and it fixes #77.