### PR TITLE
Change dependsOn from GString to String

### DIFF
--- a/src/main/groovy/nu/studer/gradle/jooq/JooqPlugin.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqPlugin.groovy
@@ -111,7 +111,7 @@ class JooqPlugin implements Plugin<Project> {
     private void configureSourceSet(JooqConfiguration jooqConfiguration) {
         SourceSet sourceSet = jooqConfiguration.sourceSet
         sourceSet.java.srcDir { jooqConfiguration.configuration.generator.target.directory }
-        project.tasks.getByName(sourceSet.compileJavaTaskName).dependsOn jooqConfiguration.jooqTaskName
+        project.tasks.getByName(sourceSet.compileJavaTaskName).dependsOn jooqConfiguration.jooqTaskName.toString()
     }
 
 }


### PR DESCRIPTION
When using this plugin with Kotlin DSL, it is not possible to disable source generation using
```kotlin
project.tasks.getByName("compileJava").dependsOn -= "generateFooJooqSchemaSource"
project.tasks.getByName("clean").dependsOn -= "cleanGenerateFooJooqSchemaSource"
```
because the `Set<Object>` `dependsOn` does not contain the `String` `generateFooJooqSchemaSource`; instead, it contains the `GStringImpl` object for this string.

Instead, and because Kotlin does not accept 
```kotlin
project.tasks.getByName("compileJava").dependsOn = set
```
(_cannot reassign val_), I had to write the following:
```kotlin
mapOf(
    "compileJava" to "generateFooJooqSchemaSource",
    "clean" to "cleanGenerateFooJooqSchemaSource"
).forEach { taskName, dependency ->
    val task = project.tasks.getByName(taskName)
    val filtered = task.dependsOn.filterNot { it.toString() == dependency }
    task.dependsOn.clear()
    task.dependsOn(*filtered.toTypedArray())
}
```
Adding the dependency with a `String` instead of a `GStringImpl` would solve this issue.