### PR TITLE
Allow preventing forced jOOQ version

### DIFF
--- a/src/main/groovy/nu/studer/gradle/jooq/JooqPlugin.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqPlugin.groovy
@@ -43,7 +43,9 @@ class JooqPlugin implements Plugin<Project> {
         project.plugins.apply(JavaBasePlugin.class)
         addJooqExtension(project)
         addJooqConfiguration(project)
-        forceJooqVersionAndEdition(project)
+        if (extension.version) {
+            forceJooqVersionAndEdition(project)
+        }
     }
 
     /**


### PR DESCRIPTION
In my project I already have project-wide platform definition and would like to manage jOOQ version directly via `jooqRuntime` configuration constraints. This would allow so via `version = ''`.