### PR TITLE
Add support for more recent jOOQ distributions

### DIFF
--- a/src/main/groovy/nu/studer/gradle/jooq/JooqEdition.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqEdition.java
@@ -9,8 +9,11 @@ public enum JooqEdition {
 
     OSS("org.jooq"),
     PRO("org.jooq.pro"),
+    PRO_JAVA_8("org.jooq.pro-java-8"),
     PRO_JAVA_6("org.jooq.pro-java-6"),
-    TRIAL("org.jooq.trial");
+    TRIAL("org.jooq.trial"),
+    TRIAL_JAVA_8("org.jooq.trial-java-8"),
+    TRIAL_JAVA_6("org.jooq.trial-java-6");
 
     private final String groupId;
 


### PR DESCRIPTION
We've recently added additional distributions to jOOQ:

- `org.jooq.pro-java-8`: Since jOOQ 3.12, we formally support Java 11+ under the `org.jooq.pro` group ID. Java 8 support will be continued under this new group ID
- Starting with jOOQ 3.12.4, we've supported Java 6 and 8 distributions also for the free trial

These are currently all group IDs in jOOQ 3.13 and 3.14. If we add new ones, I'll try to remember to send another PR