### PR TITLE
Update postgresql driver in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Depending on which database you are connecting to, you need to put the correspon
 
 ```groovy
 dependencies {
-    jooqRuntime 'postgresql:postgresql:9.1-901.jdbc4'
+    jooqRuntime 'org.postgresql:postgresql:42.2.12'
 }
 ```
 


### PR DESCRIPTION
`postgresql:postgresql` was last updated in 2011. I wouldn't want anyone thinking they should use that