### PR TITLE
Chore: Update jooq default version to 3.14.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ name of the declared jOOQ configuration.
 
 ```groovy
 jooq {
-  version = '3.14.1'  // the default (can be omitted)
+  version = '3.14.7'  // the default (can be omitted)
   edition = nu.studer.gradle.jooq.JooqEdition.OSS  // the default (can be omitted)
 }
 ```
@@ -123,7 +123,7 @@ jooq {
 
 ```kotlin
 jooq {
-  version.set("3.14.1")  // the default (can be omitted)
+  version.set("3.14.7")  // the default (can be omitted)
   edition.set(nu.studer.gradle.jooq.JooqEdition.OSS)  // the default (can be omitted)
 }
 ```
@@ -170,7 +170,7 @@ explicitly setting the `directory` attribute of the `target` configuration of th
 
 ```groovy
 jooq {
-    version = '3.14.1'  // default (can be omitted)
+    version = '3.14.7'  // default (can be omitted)
     edition = nu.studer.gradle.jooq.JooqEdition.OSS  // default (can be omitted)
 
     configurations {
@@ -233,7 +233,7 @@ See the [Examples](#examples) section for complete, exemplary build scripts that
 
 ```kotlin
 jooq {
-    version.set("3.14.1")  // default (can be omitted)
+    version.set("3.14.7")  // default (can be omitted)
     edition.set(nu.studer.gradle.jooq.JooqEdition.OSS)  // default (can be omitted)
 
     configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ group = 'nu.studer'
 version = '5.2.1-DEV'
 
 dependencies {
-    api 'org.jooq:jooq-codegen:3.14.1'
+    api 'org.jooq:jooq-codegen:3.14.7'
 
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.glassfish.jaxb:jaxb-core:2.3.0.1'

--- a/example/configure_custom_generator_strategy/custom-generator-strategy/build.gradle
+++ b/example/configure_custom_generator_strategy/custom-generator-strategy/build.gradle
@@ -5,5 +5,5 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.jooq:jooq-codegen:3.14.1'
+    implementation 'org.jooq:jooq-codegen:3.14.7'
 }

--- a/example/extract_precompiled_script_plugin/buildSrc/src/main/groovy/jooq-convention.gradle
+++ b/example/extract_precompiled_script_plugin/buildSrc/src/main/groovy/jooq-convention.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 jooq {
-    version = '3.14.1'
+    version = '3.14.7'
     edition = JooqEdition.OSS
 
     configurations {

--- a/example/use_groovy_dsl/build.gradle
+++ b/example/use_groovy_dsl/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 jooq {
-    version = '3.14.1'
+    version = '3.14.7'
     edition = JooqEdition.OSS
 
     configurations {

--- a/example/use_kotlin_dsl/build.gradle.kts
+++ b/example/use_kotlin_dsl/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 }
 
 jooq {
-    version.set("3.14.1")
+    version.set("3.14.7")
     edition.set(JooqEdition.OSS)
 
     configurations {

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqExtension.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqExtension.java
@@ -8,7 +8,7 @@ import javax.inject.Inject;
 
 public class JooqExtension {
 
-    private static final String DEFAULT_VERSION = "3.14.1";
+    private static final String DEFAULT_VERSION = "3.14.7";
     private static final JooqEdition DEFAULT_EDITION = JooqEdition.OSS;
 
     private final Property<String> version;

--- a/src/test/groovy/nu/studer/gradle/jooq/JooqFuncTest.groovy
+++ b/src/test/groovy/nu/studer/gradle/jooq/JooqFuncTest.groovy
@@ -114,7 +114,7 @@ dependencies {
 }
 
 jooq {
-    version.set("3.14.1")
+    version.set("3.14.7")
     configurations {
         create("main") {
             jooqConfiguration.apply {
@@ -725,7 +725,7 @@ dependencies {
 }
 
 jooq {
-  version = '3.14.1'
+  version = '3.14.7'
   edition = nu.studer.gradle.jooq.JooqEdition.OSS
   configurations {
     main {
@@ -903,7 +903,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.jooq:jooq-codegen:3.14.1'
+    implementation 'org.jooq:jooq-codegen:3.14.7'
 }
 """
     }


### PR DESCRIPTION
This updates the default version to 3.14.7 for JOOQ. 

I was hoping to upgrade so the Kotlin generator will be available.