### PR TITLE
Use `mainClass` property instead of deprecated `main`

### DIFF
--- a/src/main/groovy/nu/studer/gradle/jooq/JooqGenerate.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqGenerate.java
@@ -263,7 +263,7 @@ public class JooqGenerate extends DefaultTask {
 
     private ExecResult executeJooq(final File configFile) {
         return execOperations.javaexec(spec -> {
-            spec.setMain("org.jooq.codegen.GenerationTool");
+            spec.getMainClass().set("org.jooq.codegen.GenerationTool");
             spec.setClasspath(runtimeClasspath);
             spec.setWorkingDir(projectLayout.getProjectDirectory());
             spec.args(configFile);


### PR DESCRIPTION
This hopefully quiets Gradle 7's grumbling about deprecation.