### PR TITLE
Add support for new jOOQ 3.15 distributions

### DIFF
--- a/src/main/groovy/nu/studer/gradle/jooq/JooqEdition.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqEdition.java
@@ -24,9 +24,11 @@ public enum JooqEdition {
 
     OSS("org.jooq"),
     PRO("org.jooq.pro"),
+    PRO_JAVA_11("org.jooq.pro-java-11"),
     PRO_JAVA_8("org.jooq.pro-java-8"),
     PRO_JAVA_6("org.jooq.pro-java-6"),
     TRIAL("org.jooq.trial"),
+    TRIAL_JAVA_11("org.jooq.trial-java-11"),
     TRIAL_JAVA_8("org.jooq.trial-java-8"),
     TRIAL_JAVA_6("org.jooq.trial-java-6");
 


### PR DESCRIPTION
I've just published jOOQ 3.15, see:
https://blog.jooq.org/2021/07/06/3-15-0-release-with-support-for-r2dbc-nested-row-array-and-multiset-types-5-new-sql-dialects-create-procedure-function-and-trigger-support-and-much-more/

jOOQ 3.15 includes the following changes that are relevant for your plugin:

- The commercial editions now have a new Java 11 distribution. The default distribution is a Java 17 distribution (currently supporting Java 16)
- Support for the Java 6 distribution has been dropped in jOOQ 3.15, though I guess you should keep that enum value for now, in case someone uses jOOQ 3.14 or less
- The open source edition requires Java 11 starting from jOOQ 3.15

Let me know if you need any additional info and I'll be very happy to help.