### PR TITLE
Examples should use case-insensitive matching of include types

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,11 +264,11 @@ jooq {
                             ForcedType()
                                 .withName("varchar")
                                 .withIncludeExpression(".*")
-                                .withIncludeTypes("JSONB?"),
+                                .withIncludeTypes("(?i:jsonb?)"),
                             ForcedType()
                                 .withName("varchar")
                                 .withIncludeExpression(".*")
-                                .withIncludeTypes("INET")
+                                .withIncludeTypes("(?i:inet)")
                         ).toList())
                     }
                     generate.apply {

--- a/example/use_kotlin_dsl/build.gradle.kts
+++ b/example/use_kotlin_dsl/build.gradle.kts
@@ -38,11 +38,11 @@ jooq {
                             ForcedType()
                                 .withName("varchar")
                                 .withIncludeExpression(".*")
-                                .withIncludeTypes("JSONB?"),
+                                .withIncludeTypes("(?i:jsonb?)"),
                             ForcedType()
                                 .withName("varchar")
                                 .withIncludeExpression(".*")
-                                .withIncludeTypes("INET")
+                                .withIncludeTypes("(?i:inet)")
                         ).toList())
                     }
                     generate.apply {


### PR DESCRIPTION
The examples use upper case data type regular expressions, which currently don't match anything in PostgreSQL, so the examples are wrong. There are 2 ways to fix this:

- Use lower case data type references instead, which fixes things for PostgreSQL, but creates the same confusion for many other dialects (e.g. Oracle)
- Use a case insensitive regular expression instead, to remind users that this is possible. This might need an explanation, if users aren't aware of these `(?i:...)` directives being a thing?