### PR TITLE
Update to the latest gradle-build-action

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -17,9 +17,6 @@ jobs:
                 with:
                     java-version: 11
             -   name: Build with Gradle
-                uses: gradle/gradle-build-action@v1
+                uses: gradle/gradle-build-action@v2
                 with:
                     arguments: build -PtestJavaRuntimeVersion=${{ matrix.java-version }} -PtestGradleVersion=${{ matrix.gradle-version }} -Pgradle-jooq-plugin.acceptGradleTOS=true
-                    distributions-cache-enabled: true
-                    dependencies-cache-enabled: true
-                    configuration-cache-enabled: false


### PR DESCRIPTION
Switch to gradle/gradle-build-action@v2, which currently points to v2.0-beta.2.