### PR TITLE
Add JVM toolchain support for Gradle 7.3.3 and above

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 java-version: [ 11, 16 ]
-                gradle-version: [ 6.1.1, 6.9, 7.0.2, 7.2 ]
+                gradle-version: [ 6.1.1, 6.9, 7.0.2, 7.2, 7.3]
         name: Test JVM/Gradle (${{ matrix.java-version }}, ${{ matrix.gradle-version }})
         steps:
             -   name: Check out project

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 java-version: [ 11, 16 ]
-                gradle-version: [ 6.1.1, 6.9, 7.0.2, 7.2, 7.3.3 ]
+                gradle-version: [ 6.1.1, 6.9, 7.0.2, 7.1.1, 7.2, 7.3.3 ]
         name: Test JVM/Gradle (${{ matrix.java-version }}, ${{ matrix.gradle-version }})
         steps:
             -   name: Check out project

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 java-version: [ 11, 16 ]
-                gradle-version: [ 6.1.1, 6.9, 7.0.2, 7.2, 7.3]
+                gradle-version: [ 6.1.1, 6.9, 7.0.2, 7.2, 7.3.3 ]
         name: Test JVM/Gradle (${{ matrix.java-version }}, ${{ matrix.gradle-version }})
         steps:
             -   name: Check out project

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqGenerate.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqGenerate.java
@@ -81,8 +81,6 @@ public abstract class JooqGenerate extends DefaultTask {
     private Action<? super JavaExecSpec> javaExecSpec;
     private Action<? super ExecResult> execResultHandler;
 
-    private final ToolchainHelper toolchainHelper;
-
     private final ProjectLayout projectLayout;
     private final ExecOperations execOperations;
     private final FileSystemOperations fileSystemOperations;
@@ -97,11 +95,12 @@ public abstract class JooqGenerate extends DefaultTask {
         this.outputDir = objects.directoryProperty().value(config.getOutputDir());
         this.allInputsDeclared = objects.property(Boolean.class).convention(Boolean.FALSE);
 
-        this.toolchainHelper = new ToolchainHelper(extensions, getLauncher());
-
         this.projectLayout = projectLayout;
         this.execOperations = execOperations;
         this.fileSystemOperations = fileSystemOperations;
+
+        // Gradle toolchain support is only available as of Gradle 6.7
+        ToolchainHelper.tryConfigureJavaLauncher(getLauncher(), extensions);
 
         // do not use lambda due to a bug in Gradle 6.5
         getOutputs().upToDateWhen(new Spec<Task>() {
@@ -287,7 +286,7 @@ public abstract class JooqGenerate extends DefaultTask {
             spec.setClasspath(runtimeClasspath);
             spec.setWorkingDir(projectLayout.getProjectDirectory());
             spec.args(configFile);
-            toolchainHelper.setExec(spec);
+            ToolchainHelper.tryApplyJavaLauncher(getLauncher(), spec);
             if (javaExecSpec != null) {
                 javaExecSpec.execute(spec);
             }

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqPlugin.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqPlugin.java
@@ -41,7 +41,7 @@ public class JooqPlugin implements Plugin<Project> {
         // create a jooq task for each jooq configuration domain object
         jooqExtension.getConfigurations().configureEach(config -> {
             String taskName = "generate" + (config.name.equals("main") ? "" : capitalize(config.name)) + "Jooq";
-            TaskProvider<JooqGenerate> jooq = project.getTasks().register(taskName, JooqGenerate.class, config, runtimeConfiguration);
+            TaskProvider<JooqGenerate> jooq = project.getTasks().register(taskName, JooqGenerate.class, config, runtimeConfiguration, project.getExtensions());
             jooq.configure(task -> {
                 task.setDescription(String.format("Generates the jOOQ sources from the %s jOOQ configuration.", config.name));
                 task.setGroup("jOOQ");

--- a/src/main/groovy/nu/studer/gradle/jooq/ToolchainHelper.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/ToolchainHelper.java
@@ -27,10 +27,10 @@ abstract class ToolchainHelper {
     }
 
     static void tryApplyJavaLauncher(Property<Object> launcher, JavaExecSpec spec) {
-        if (Gradles.isAtLeastGradleVersion(INITIAL_TOOLCHAIN_SUPPORT) && launcher.isPresent() && launcher.get() instanceof JavaLauncher) {
-            spec.setExecutable(((JavaLauncher) launcher.get()).getExecutablePath().getAsFile().getAbsolutePath());
-        } else if (!Gradles.isAtLeastGradleVersion(INITIAL_TOOLCHAIN_SUPPORT) && launcher.isPresent()) {
-            throw new IllegalArgumentException("Toolchain support requires Gradle " + INITIAL_TOOLCHAIN_SUPPORT);
+        if (Gradles.isAtLeastGradleVersion(INITIAL_TOOLCHAIN_SUPPORT)) {
+            if (launcher.isPresent() && launcher.get() instanceof JavaLauncher) {
+                spec.setExecutable(((JavaLauncher) launcher.get()).getExecutablePath().getAsFile().getAbsolutePath());
+            }
         }
     }
 

--- a/src/main/groovy/nu/studer/gradle/jooq/ToolchainHelper.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/ToolchainHelper.java
@@ -1,7 +1,6 @@
 package nu.studer.gradle.jooq;
 
 import nu.studer.gradle.jooq.util.Gradles;
-import org.gradle.api.Task;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Property;
@@ -12,14 +11,16 @@ import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.process.JavaExecSpec;
 
 /**
- * This isolates toolchain related types, introduced in 6.7 and above.
+ * Isolates Gradle toolchain related types, introduced in 6.7 and above.
  */
 class ToolchainHelper {
+
     private static final String GRADLE_VERSION_WITH_TOOLCHAIN = "7.3";
+
     private final boolean supportsToolchainAndConfigurationCache;
     private final Property<Object> launcher;
 
-    public ToolchainHelper(ExtensionContainer extensions, Property<Object> launcher) {
+    ToolchainHelper(ExtensionContainer extensions, Property<Object> launcher) {
         this.launcher = launcher;
         this.supportsToolchainAndConfigurationCache = Gradles.isAtLeastGradleVersion(GRADLE_VERSION_WITH_TOOLCHAIN);
         if (supportsToolchainAndConfigurationCache) {
@@ -37,4 +38,5 @@ class ToolchainHelper {
             throw new IllegalArgumentException("Toolchain support requires Gradle " + GRADLE_VERSION_WITH_TOOLCHAIN);
         }
     }
+
 }

--- a/src/main/groovy/nu/studer/gradle/jooq/ToolchainHelper.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/ToolchainHelper.java
@@ -1,0 +1,40 @@
+package nu.studer.gradle.jooq;
+
+import nu.studer.gradle.jooq.util.Gradles;
+import org.gradle.api.Task;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.process.JavaExecSpec;
+
+/**
+ * This isolates toolchain related types, introduced in 6.7 and above.
+ */
+class ToolchainHelper {
+    private static final String GRADLE_VERSION_WITH_TOOLCHAIN = "7.3";
+    private final boolean supportsToolchainAndConfigurationCache;
+    private final Property<Object> launcher;
+
+    public ToolchainHelper(ExtensionContainer extensions, Property<Object> launcher) {
+        this.launcher = launcher;
+        this.supportsToolchainAndConfigurationCache = Gradles.isAtLeastGradleVersion(GRADLE_VERSION_WITH_TOOLCHAIN);
+        if (supportsToolchainAndConfigurationCache) {
+            JavaToolchainSpec toolchain = extensions.getByType(JavaPluginExtension.class).getToolchain();
+            JavaToolchainService service = extensions.getByType(JavaToolchainService.class);
+            Provider<JavaLauncher> defaultLauncher = service.launcherFor(toolchain);
+            launcher.convention(defaultLauncher);
+        }
+    }
+
+    void setExec(JavaExecSpec spec) {
+        if (supportsToolchainAndConfigurationCache && launcher.isPresent() && launcher.get() instanceof JavaLauncher) {
+            spec.setExecutable(((JavaLauncher) launcher.get()).getExecutablePath().getAsFile().getAbsolutePath());
+        } else if (!supportsToolchainAndConfigurationCache && launcher.isPresent()) {
+            throw new IllegalArgumentException("Toolchain support requires Gradle " + GRADLE_VERSION_WITH_TOOLCHAIN);
+        }
+    }
+}

--- a/src/main/groovy/nu/studer/gradle/jooq/ToolchainHelper.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/ToolchainHelper.java
@@ -15,10 +15,10 @@ import org.gradle.process.JavaExecSpec;
  */
 abstract class ToolchainHelper {
 
-    private static final String GRADLE_VERSION_WITH_TOOLCHAIN = "7.3";
+    private static final String INITIAL_TOOLCHAIN_SUPPORT = "6.7";
 
     static void tryConfigureJavaLauncher(Property<Object> launcher, ExtensionContainer extensions) {
-        if (Gradles.isAtLeastGradleVersion(GRADLE_VERSION_WITH_TOOLCHAIN)) {
+        if (Gradles.isAtLeastGradleVersion(INITIAL_TOOLCHAIN_SUPPORT)) {
             JavaToolchainSpec toolchain = extensions.getByType(JavaPluginExtension.class).getToolchain();
             JavaToolchainService service = extensions.getByType(JavaToolchainService.class);
             Provider<JavaLauncher> defaultLauncher = service.launcherFor(toolchain);
@@ -27,10 +27,10 @@ abstract class ToolchainHelper {
     }
 
     static void tryApplyJavaLauncher(Property<Object> launcher, JavaExecSpec spec) {
-        if (Gradles.isAtLeastGradleVersion(GRADLE_VERSION_WITH_TOOLCHAIN) && launcher.isPresent() && launcher.get() instanceof JavaLauncher) {
+        if (Gradles.isAtLeastGradleVersion(INITIAL_TOOLCHAIN_SUPPORT) && launcher.isPresent() && launcher.get() instanceof JavaLauncher) {
             spec.setExecutable(((JavaLauncher) launcher.get()).getExecutablePath().getAsFile().getAbsolutePath());
-        } else if (!Gradles.isAtLeastGradleVersion(GRADLE_VERSION_WITH_TOOLCHAIN) && launcher.isPresent()) {
-            throw new IllegalArgumentException("Toolchain support requires Gradle " + GRADLE_VERSION_WITH_TOOLCHAIN);
+        } else if (!Gradles.isAtLeastGradleVersion(INITIAL_TOOLCHAIN_SUPPORT) && launcher.isPresent()) {
+            throw new IllegalArgumentException("Toolchain support requires Gradle " + INITIAL_TOOLCHAIN_SUPPORT);
         }
     }
 

--- a/src/test/groovy/nu/studer/gradle/jooq/JooqFuncTest.groovy
+++ b/src/test/groovy/nu/studer/gradle/jooq/JooqFuncTest.groovy
@@ -638,29 +638,6 @@ generateJooq {
         result.task(':generateJooq').outcome == TaskOutcome.SUCCESS
     }
 
-    @Requires({
-        determineGradleVersion().baseVersion >= GradleVersion.version("6.7") &&
-            determineGradleVersion().baseVersion < GradleVersion.version("7.3")
-    })
-    void "invoke jOOQ task and use specific JVM Toolchains fails at execution time"() {
-        given:
-        buildFile << buildWithJooqPluginDSL()
-        buildFile << """
-generateJooq {
-    launcher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
-}
-"""
-        when:
-        def result = runAndFailWithArguments('generateJooq')
-
-        then:
-        !fileExists('build/generated-src/jooq/main/nu/studer/sample/jooq_test/tables/Foo.java')
-        result.task(':generateJooq').outcome == TaskOutcome.FAILED
-        result.output.contains('Toolchain support requires Gradle 7.3')
-    }
-
     @Requires({ (determineGradleVersion().baseVersion < GradleVersion.version("6.7")) })
     void "invoke jOOQ task and use JVM Toolchains fails at configuration time"() {
         given:
@@ -681,8 +658,8 @@ java {
         result.output.contains('Could not find method toolchain()')
     }
 
-    @Requires({ (determineGradleVersion().baseVersion >= GradleVersion.version('7.3')) })
-    void "can invoke jOOQ task and use JVM Toolchains"() {
+    @Requires({ (determineGradleVersion().baseVersion >= GradleVersion.version('6.7')) })
+    void "can invoke jOOQ task and use default JVM toolchain"() {
         given:
         buildFile << buildWithJooqPluginDSL()
         buildFile << """
@@ -694,7 +671,7 @@ java {
 
 generateJooq {
     doFirst {
-       println("Running jooq task with JDK \${it.launcher.get().metadata.languageVersion.asInt()}")
+       println("Running jOOQ task with JDK \${it.launcher.get().metadata.languageVersion.asInt()}")
     }
 }
 """
@@ -705,11 +682,11 @@ generateJooq {
         then:
         fileExists('build/generated-src/jooq/main/nu/studer/sample/jooq_test/tables/Foo.java')
         result.task(':generateJooq').outcome == TaskOutcome.SUCCESS
-        result.output.contains('Running jooq task with JDK 11')
+        result.output.contains('Running jOOQ task with JDK 11')
     }
 
     @Requires({ (determineGradleVersion().baseVersion >= GradleVersion.version('7.3')) })
-    void "can invoke jOOQ task and override JVM Toolchains"() {
+    void "can invoke jOOQ task and override default JVM toolchain"() {
         given:
         buildFile << buildWithJooqPluginDSL()
         buildFile << """
@@ -724,7 +701,7 @@ generateJooq {
         languageVersion = JavaLanguageVersion.of(11)
     }
     doFirst {
-       println("Running jooq task with JDK \${it.launcher.get().metadata.languageVersion.asInt()}")
+       println("Running jOOQ task with JDK \${it.launcher.get().metadata.languageVersion.asInt()}")
     }
 }
 """
@@ -735,11 +712,11 @@ generateJooq {
         then:
         fileExists('build/generated-src/jooq/main/nu/studer/sample/jooq_test/tables/Foo.java')
         result.task(':generateJooq').outcome == TaskOutcome.SUCCESS
-        result.output.contains('Running jooq task with JDK 11')
+        result.output.contains('Running jOOQ task with JDK 11')
     }
 
     @Requires({ (determineGradleVersion().baseVersion >= GradleVersion.version('7.3')) })
-    void "can invoke jOOQ task from configuration DSL with Gradle configuration cache enabled and use Toolchains"() {
+    void "can invoke jOOQ task from configuration DSL with Gradle configuration cache enabled and using toolchain"() {
         given:
         buildFile << buildWithJooqPluginDSL()
         buildFile << """
@@ -754,7 +731,7 @@ generateJooq {
         languageVersion = JavaLanguageVersion.of(11)
     }
     doFirst {
-       println("Running jooq task with JDK \${it.launcher.get().metadata.languageVersion.asInt()}")
+       println("Running jOOQ task with JDK \${it.launcher.get().metadata.languageVersion.asInt()}")
     }
 }
 """
@@ -766,7 +743,7 @@ generateJooq {
         fileExists('build/generated-src/jooq/main/nu/studer/sample/jooq_test/tables/Foo.java')
         result.output.contains("Calculating task graph as no configuration cache is available for tasks: generateJooq")
         result.task(':generateJooq').outcome == TaskOutcome.SUCCESS
-        result.output.contains('Running jooq task with JDK 11')
+        result.output.contains('Running jOOQ task with JDK 11')
 
         when:
         new File(workspaceDir, 'build/generated-src/jooq/main/nu/studer/sample/jooq_test/tables/Foo.java').delete()
@@ -776,9 +753,8 @@ generateJooq {
         fileExists('build/generated-src/jooq/main/nu/studer/sample/jooq_test/tables/Foo.java')
         result.output.contains("Reusing configuration cache.")
         result.task(':generateJooq').outcome == TaskOutcome.SUCCESS
-        result.output.contains('Running jooq task with JDK 11')
+        result.output.contains('Running jOOQ task with JDK 11')
     }
-
 
     private static String buildWithJooqPluginDSL(String targetPackageName = null,
                                                  String targetDirectory = null,


### PR DESCRIPTION
JVM toolchain works fine with configuration cache since Gradle 7.3, this PR implements this and makes sure it does not fail the build for earlier Gradle versions:
- `< 6.7` (no toolchain support at all)
- `>= 6.7 and < 7.3` (toolchain support without configuration cache)
