### PR TITLE
Use jOOQ-3.16-compatible way of getting XSD class path

### DIFF
--- a/src/main/groovy/nu/studer/gradle/jooq/JooqGenerate.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqGenerate.java
@@ -58,6 +58,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.Arrays;
 
 import static nu.studer.gradle.jooq.util.Objects.cloneObject;
 
@@ -242,7 +245,14 @@ public class JooqGenerate extends DefaultTask {
     private void writeConfiguration(Configuration config, File file) {
         try (OutputStream fs = new FileOutputStream(file)) {
             SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-            Schema schema = sf.newSchema(GenerationTool.class.getResource("/xsd/" + xsdFileName()));
+            String resourceFileName = xsdResourcePath();
+            URL schemaResourceURL = GenerationTool.class.getResource(resourceFileName);
+
+            if (schemaResourceURL == null) {
+                throw new GradleException("Failed to locate schema named " + resourceFileName + ". Is the proper jOOQ version available on the class path?");
+            }
+
+            Schema schema = sf.newSchema(schemaResourceURL);
 
             JAXBContext ctx = JAXBContext.newInstance(Configuration.class);
             Marshaller marshaller = ctx.createMarshaller();
@@ -254,11 +264,22 @@ public class JooqGenerate extends DefaultTask {
         }
     }
 
-    private String xsdFileName() {
-        // use reflection to avoid inlining of the String constant org.jooq.Constants.XSD_CODEGEN
+    private String xsdResourcePath() {
         try {
-            Class<?> aClass = Class.forName("org.jooq.Constants");
-            return (String) aClass.getDeclaredField("XSD_CODEGEN").get(null);
+            // use reflection to be able to handle different jOOQ versions gracefully. (Even without
+            // this, using reflection here is mandatory to prevent field inlining, i.e. tightly
+            // coupling the plugin version to a particular jOOQ release.)
+            Class<?> jooqConstants = Class.forName("org.jooq.Constants");
+
+            if (Arrays.stream(jooqConstants.getDeclaredFields())
+                    .map(Field::getName)
+                    .anyMatch(s -> s.equals("CP_CODEGEN"))) {
+                // jOOQ >= 3.12.0; we can use the "new" approach of constructing the XSD class path.
+                return (String) jooqConstants.getDeclaredField("CP_CODEGEN").get(null);
+            } else {
+                // For older versions, we resort to the previous hardwired approach.
+                return "/xsd/" + jooqConstants.getDeclaredField("XSD_CODEGEN").get(null);
+            }
         } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
             throw new TaskExecutionException(JooqGenerate.this, e);
         }


### PR DESCRIPTION
The approach taken here should be fine on older jOOQ versions as well. Extra care was taken to use reflection and try to degrade gracefully on jOOQ < 3.12 releases as well.

(Includes #205 as well, so if this gets approved we can drop that other PR.)