### PR TITLE
Fix: Allow use of jakarta.xml (jOOQ 3.16+) alongside javax.xml (jOOQ < 3.16)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ version = '6.0.2-DEV'
 
 dependencies {
     api 'org.jooq:jooq-codegen:3.15.1'
+    api 'org.jooq:jooq-meta:3.15.1'
 
     runtimeOnly 'com.sun.xml.bind:jaxb-impl:3.0.0'
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,11 @@ version = '6.0.2-DEV'
 dependencies {
     api 'org.jooq:jooq-codegen:3.15.1'
 
+    runtimeOnly 'com.sun.xml.bind:jaxb-impl:3.0.0'
+    runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.3'
+    runtimeOnly 'org.glassfish.jaxb:jaxb-core:2.3.0.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
-    implementation 'org.glassfish.jaxb:jaxb-core:2.3.0.1'
-    implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.3'
-    implementation 'javax.activation:activation:1.1.1'
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.0'
 
     testImplementation 'com.h2database:h2:1.4.200'
     testImplementation 'org.spockframework:spock-core:2.0-groovy-2.5'

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqGenerate.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqGenerate.java
@@ -58,6 +58,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.Arrays;
 
 import static nu.studer.gradle.jooq.util.Objects.cloneObject;
 
@@ -242,7 +245,14 @@ public class JooqGenerate extends DefaultTask {
     private void writeConfiguration(Configuration config, File file) {
         try (OutputStream fs = new FileOutputStream(file)) {
             SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-            Schema schema = sf.newSchema(GenerationTool.class.getResource("/xsd/" + xsdFileName()));
+            String resourceFileName = xsdResourcePath();
+            URL schemaResourceURL = GenerationTool.class.getResource(resourceFileName);
+
+            if (schemaResourceURL == null) {
+                throw new GradleException("Failed to locate schema named " + resourceFileName + ". Is the proper jOOQ version available on the class path?");
+            }
+
+            Schema schema = sf.newSchema(schemaResourceURL);
 
             JAXBContext ctx = JAXBContext.newInstance(Configuration.class);
             Marshaller marshaller = ctx.createMarshaller();
@@ -254,11 +264,22 @@ public class JooqGenerate extends DefaultTask {
         }
     }
 
-    private String xsdFileName() {
-        // use reflection to avoid inlining of the String constant org.jooq.Constants.XSD_CODEGEN
+    private String xsdResourcePath() {
         try {
-            Class<?> aClass = Class.forName("org.jooq.Constants");
-            return (String) aClass.getDeclaredField("XSD_CODEGEN").get(null);
+            // use reflection to be able to handle different jOOQ versions gracefully. (Even without
+            // this, using reflection here is mandatory to prevent field inlining, i.e. tightly
+            // coupling the plugin version to a particular jOOQ release.)
+            Class<?> jooqConstants = Class.forName("org.jooq.Constants");
+
+            if (Arrays.stream(jooqConstants.getDeclaredFields())
+                    .map(Field::getName)
+                    .anyMatch(s -> s.equals("CP_CODEGEN"))) {
+                // jOOQ >= 3.12.0; we can use the "new" approach of constructing the XSD class path.
+                return (String) jooqConstants.getDeclaredField("CP_CODEGEN").get(null);
+            } else {
+                // For older versions, we resort to the previous hardwired approach.
+                return "/xsd/" + jooqConstants.getDeclaredField("XSD_CODEGEN").get(null);
+            }
         } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
             throw new TaskExecutionException(JooqGenerate.this, e);
         }

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqGenerate.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqGenerate.java
@@ -49,9 +49,6 @@ import org.xml.sax.SAXException;
 
 import javax.inject.Inject;
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import java.io.File;
@@ -254,12 +251,18 @@ public class JooqGenerate extends DefaultTask {
 
             Schema schema = sf.newSchema(schemaResourceURL);
 
-            JAXBContext ctx = JAXBContext.newInstance(Configuration.class);
-            Marshaller marshaller = ctx.createMarshaller();
-            marshaller.setSchema(schema);
-
-            marshaller.marshal(config, fs);
-        } catch (IOException | JAXBException | SAXException e) {
+            if (config.getClass().isAnnotationPresent(jakarta.xml.bind.annotation.XmlRootElement.class)) {
+                jakarta.xml.bind.JAXBContext ctx = jakarta.xml.bind.JAXBContext.newInstance(Configuration.class);
+                jakarta.xml.bind.Marshaller marshaller = ctx.createMarshaller();
+                marshaller.setSchema(schema);
+                marshaller.marshal(config, fs);
+            } else {
+                javax.xml.bind.JAXBContext ctx = javax.xml.bind.JAXBContext.newInstance(Configuration.class);
+                javax.xml.bind.Marshaller marshaller = ctx.createMarshaller();
+                marshaller.setSchema(schema);
+                marshaller.marshal(config, fs);
+            }
+        } catch (IOException | jakarta.xml.bind.JAXBException | javax.xml.bind.JAXBException | SAXException e) {
             throw new TaskExecutionException(JooqGenerate.this, e);
         }
     }

--- a/src/main/groovy/nu/studer/gradle/jooq/jaxb/JaxbConfigurationBridge.groovy
+++ b/src/main/groovy/nu/studer/gradle/jooq/jaxb/JaxbConfigurationBridge.groovy
@@ -20,7 +20,6 @@ import org.jooq.Constants
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import javax.xml.bind.annotation.XmlElement
 import java.lang.reflect.Field
 import java.lang.reflect.ParameterizedType
 
@@ -64,7 +63,13 @@ class JaxbConfigurationBridge {
 
                 // determine the name of a list element and the element type
                 Field field = target.class.declaredFields.find { it.name == "$methodName" }
-                String nameOfChildren = field.getAnnotation(XmlElement).name()
+                String nameOfChildren
+                if (field.isAnnotationPresent(jakarta.xml.bind.annotation.XmlElement)) {
+                    nameOfChildren = field.getAnnotation(jakarta.xml.bind.annotation.XmlElement).name()
+                } else {
+                    nameOfChildren = field.getAnnotation(javax.xml.bind.annotation.XmlElement).name()
+                }
+
                 ParameterizedType elementType = field.getGenericType()
                 Class classOfChildren = elementType.actualTypeArguments.first()
 

--- a/src/test/groovy/nu/studer/gradle/jooq/JooqFuncTest.groovy
+++ b/src/test/groovy/nu/studer/gradle/jooq/JooqFuncTest.groovy
@@ -54,6 +54,20 @@ tasks.named('generateJooq').configure { outputs.cacheIf { true } }
         result.task(':generateJooq').outcome == TaskOutcome.SUCCESS
     }
 
+    void "can invoke jOOQ task from configuration DSL with configuration name omitted from task name for 'main' configuration and jOOQ v3.16+"() {
+        given:
+        buildFile << buildWithJooqPluginDSL(null, null, null, '3.16.3', null)
+
+        when:
+        def result = runWithArguments('generateJooq')
+
+        then:
+        fileExists('build/generated-src/jooq/main/nu/studer/sample/jooq_test/tables/Foo.java')
+
+        and:
+        result.task(':generateJooq').outcome == TaskOutcome.SUCCESS
+    }
+
     @Requires({ (determineGradleVersion().baseVersion >= GradleVersion.version('7.0')) })
     void "can invoke jOOQ task from configuration DSL with Gradle configuration cache enabled"() {
         given:


### PR DESCRIPTION
This PR aims to fix the exception at codegen caused by the replacement of javax.xml classes by jakarta.xml classes since 3.16 in https://github.com/jOOQ/jOOQ/issues/9641.

It makes the plugin depend on both javax.xml.bind:jaxb-api and jakarta.xml.bind:jakarta.xml.bind-api and the choice is made at runtime by detecting to which package the annotations used by jOOQ classes belong to.

So far the tests work well when the plugin is compiled with 3.15.1 or 3.16.3 and I'm using the fix locally with jOOQ 3.16.3.