### PR TITLE
#625 Prevent race condition when checking if inputs are up-to-date

### DIFF
--- a/src/main/groovy/nu/studer/gradle/jooq/util/Objects.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/util/Objects.java
@@ -86,6 +86,7 @@ public final class Objects {
 
     /**
      * Calculates a hash of the given object from its serialized version.
+     * This method is thread-safe, can be used in parallel builds without an issue.
      *
      * @param obj the object for which to calculate the hash
      * @return the hash
@@ -101,7 +102,10 @@ public final class Objects {
             }
 
             StringBuilder hexString = new StringBuilder();
-            byte[] encodedHash = MESSAGE_DIGEST.digest(bas.toByteArray());
+            byte[] encodedHash;
+            synchronized (MESSAGE_DIGEST) {
+                encodedHash = MESSAGE_DIGEST.digest(bas.toByteArray());
+            }
             for (byte hash : encodedHash) {
                 String hex = Integer.toHexString(0xff & hash);
                 if (hex.length() == 1) {


### PR DESCRIPTION
Related to #625

I know that this way of solving concurrency issues is rather low effort, but the alternative is to create separate message digests to reduce contention, which creates slightly more waste in case of non-parallel multi-project builds. I'm open to adjusting to whatever you prefer.

I don't think this solution (or any other, really) is reasonably testable either, so I'm not including any test. I was no longer able to reproduce #625 manually after introducing this change.