### PR TITLE
fix: lazy configuration not possible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ gradlePlugin {
     vcsUrl = 'https://github.com/etiennestuder/gradle-jooq-plugin'
     plugins {
         pluginDevPlugin {
-            id = 'nu.studer.jooq'
+            id = 'nu.studer.jooq.withugglypatch'
             displayName = 'gradle-jooq-plugin'
             description = 'Gradle plugin that integrates jOOQ.'
             tags.set(['jooq'])


### PR DESCRIPTION
It's not possible to use lazy configurations using things like `NamedDomainObjectContainer#register` because the collection is never evaluated! While `configureEach` is lazy within itself, the collection is never queried - so it is never even instantiated because why would it - nobody ready it.

This problem is currently not solvable without forcing users to access `generateJooq` task without wrapping it in `afterEvaluate`!

This can only be solved without a breaking change if https://github.com/gradle/gradle/issues/26881 is resolved.

REF: https://github.com/gradle/gradle/issues/26881