### PR TITLE
Dependency graph is submitted to GitHub on CI builds

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,6 +1,9 @@
 name: "Build Gradle project"
 on: [ push, pull_request, workflow_dispatch ]
 
+permissions:
+    contents: write
+
 jobs:
     build:
         name: Test JVM/Gradle (${{ matrix.java-version }}, ${{ matrix.gradle-version }})
@@ -19,6 +22,8 @@ jobs:
                   distribution: 'liberica'
             - name: Setup Gradle
               uses: gradle/gradle-build-action@v2
+              with:
+                  dependency-graph: generate-and-submit
             - name: Build with Gradle
               run: "./gradlew clean build -PtestJavaRuntimeVersion=${{ matrix.java-version }} -PtestGradleVersion=${{ matrix.gradle-version }}"
               env:


### PR DESCRIPTION
This PR updates the existing Gradle build workflow to also submit the dependency graph to GitHub.

You can see what this looks like on my fork: https://github.com/erichaagdev/gradle-jooq-plugin/network/dependencies