### PR TITLE
Configuration name is exposed via getter

### DIFF
--- a/src/main/groovy/nu/studer/gradle/jooq/JooqConfig.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqConfig.java
@@ -52,17 +52,17 @@ public class JooqConfig {
                 )
             );
     }
-
+    
+    public String getName() {
+        return name;
+    }
+    
     public Configuration getJooqConfiguration() {
         return jooqConfiguration;
     }
 
     public Property<Boolean> getGenerateSchemaSourceOnCompilation() {
         return generateSchemaSourceOnCompilation;
-    }
-
-    public String getName() {
-        return name;
     }
 
     public Provider<Directory> getOutputDir() {

--- a/src/main/groovy/nu/studer/gradle/jooq/JooqConfig.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqConfig.java
@@ -61,6 +61,10 @@ public class JooqConfig {
         return generateSchemaSourceOnCompilation;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public Provider<Directory> getOutputDir() {
         return outputDir;
     }


### PR DESCRIPTION
When trying to integrate this plugin with an internal plugin, we ran into a limitation caused by the name field not being public. We are trying to use the `JooqConfig` class in a new context, and not being able to access the name means we cannot implement "map jooq config name to java config name" logic in our internal plugin.

This commit adds a getter for the field to support such a use case.