### PR TITLE
Add Java 17 and Java 21 editions to JooqEdition

### DIFF
--- a/src/main/groovy/nu/studer/gradle/jooq/JooqEdition.java
+++ b/src/main/groovy/nu/studer/gradle/jooq/JooqEdition.java
@@ -24,10 +24,14 @@ public enum JooqEdition {
 
     OSS("org.jooq"),
     PRO("org.jooq.pro"),
+    PRO_JAVA_21("org.jooq.pro-java-21"),
+    PRO_JAVA_17("org.jooq.pro-java-17"),
     PRO_JAVA_11("org.jooq.pro-java-11"),
     PRO_JAVA_8("org.jooq.pro-java-8"),
     PRO_JAVA_6("org.jooq.pro-java-6"),
     TRIAL("org.jooq.trial"),
+    TRIAL_JAVA_21("org.jooq.trial-java-21"),
+    TRIAL_JAVA_17("org.jooq.trial-java-17"),
     TRIAL_JAVA_11("org.jooq.trial-java-11"),
     TRIAL_JAVA_8("org.jooq.trial-java-8"),
     TRIAL_JAVA_6("org.jooq.trial-java-6");


### PR DESCRIPTION
Hi there! I've hit a problem with jOOQ code generation using this plugin, caused by remaining on Java 17 from jOOQ `3.20.0` onwards, and it looks like there is an existing approach for Java 11 and older that I can copy.

This is the first time I've attempted to contribute to this repo, so please bear with me if I've unwittingly gone against a convention or missed some knowledge. It's not intentional.

## My problem in more detail

I have code like this in a `build.gradle.kts` file:
```
jooq {
    edition.set(JooqEdition.PRO)
    // ...
}
```

During compilation I get an error:
```
org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.jooq.pro:jooq:3.20.11.
```

This error is correct: from `3.20.0` onwards, jOOQ is publishing to the group `org.jooq.pro-java-17` for Java 17. I have to remain on Java 17 for now (despite really wanting to migrate to 21; it's unfortunately a big job with hundreds of codebases) so I've downloaded only the pro artifacts for Java 17, ignoring 21 until later. If I want to use jOOQ 3.20.x, Java 17 and this plugin then I will need this plugin to know to use the Java 17 group.

jOOQ publishes `pro-java-17`, `pro-java-21`, `trial-java-17`, and `trial-java-21` distributions, but the `JooqEdition` enum doesn't include them, making it impossible to use these distributions without a workaround.

## The pre-existing solution for older versions of Java

Fortunately, I see that the `JooqEdition` enum already has us covered for some older versions of Java.

E.g. the older pro versions:
```
    PRO_JAVA_11("org.jooq.pro-java-11"),
    PRO_JAVA_8("org.jooq.pro-java-8"),
    PRO_JAVA_6("org.jooq.pro-java-6"),
```

## Therefore my proposed solution

Can we add `PRO_JAVA_17`, `PRO_JAVA_21`, `TRIAL_JAVA_17`, and `TRIAL_JAVA_21` to the enum, following the same pattern as the existing Java 11/8/6 entries?

### Unanswered question

We're on major version 9 of this plugin, and I see that major version 10 would require Java 21. Would it be possible to publish a 9.x version that includes this change?

I don't know how you'd feel about that, nor how it would fit in with your normal releasing practices.

It would allow people like me to continue updating jOOQ versions until we can get onto Java 21 at a later date.