### PR TITLE
Onboard to the OSS Community Develocity Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="left">
   <a href="https://github.com/etiennestuder/gradle-jooq-plugin/actions?query=workflow%3A%22Build+Gradle+project%22"><img src="https://github.com/etiennestuder/gradle-jooq-plugin/workflows/Build%20Gradle%20project/badge.svg"></a>
+  <a href="https://community.develocity.cloud/scans?search.rootProjectNames=gradle-jooq-plugin"><img src="https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A" alt="Revved up by Develocity"></a>
 </p>
 
 gradle-jooq-plugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.develocity' version '4.4.0'
+    id 'com.gradle.develocity' version '4.4.1'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.6.0'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
@@ -7,7 +7,8 @@ plugins {
 def isCI = System.getenv('CI') != null
 
 develocity {
-    server = 'https://etiennestuder.develocity.cloud'
+    server = 'https://community.develocity.cloud'
+    projectId = 'etiennestuder'
 
     buildScan {
         publishing.onlyIf { it.authenticated }


### PR DESCRIPTION
# Onboard to the OSS Community Develocity Instance

This PR repoints this project's existing Develocity Build Scan® and Build Cache configuration to the **OSS Community Develocity Instance** at <https://community.develocity.cloud> under project ID `etiennestuder`.

## What this PR changes

- `settings.gradle`: `develocity.server` switches from `https://etiennestuder.develocity.cloud` to `https://community.develocity.cloud`, and `projectId = 'etiennestuder'` is added so builds are associated with the right project.
- `settings.gradle`: `com.gradle.develocity` plugin bumped from `4.4.0` to `4.4.1` (latest released).
- `README.md`: a "Revved up by Develocity" badge added inside the existing top-of-file `<p>` block, linking to the filtered Build Scan list for `gradle-jooq-plugin` on `community.develocity.cloud`.

The existing `buildScan {}` and `buildCache {}` configuration is preserved verbatim — it already matches the canonical [common-custom-user-data-gradle-plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) idioms (`publishing.onlyIf { it.authenticated }`, `uploadInBackground = !isCI`, IP obfuscation, `push = isCI && accessKey`). GitHub Actions workflows are unchanged — they already pass `develocity-access-key` from the `DV_ACCESS_KEY` repository secret.

## Required next step — update the existing GitHub Actions secret

The workflows already reference `${{ secrets.DV_ACCESS_KEY }}`. To publish Build Scans and write to the remote Build Cache from CI against the new instance, **update the value** of that existing secret so it includes the community host:

```
DV_ACCESS_KEY = community.develocity.cloud=<your-community-access-key>
```

The hostname prefix is required — without `community.develocity.cloud=`, the access key is silently ignored. If you currently have multiple `host=key` pairs in this secret, either replace the `etiennestuder.develocity.cloud=…` entry with the community one, or keep both separated by `;` (multi-host values are supported).

To get an access key: visit <https://community.develocity.cloud>, sign in, and use **My settings → Access keys**.

## Why the CI run on this PR doesn't prove the connection works

This PR was prepared from a fork. Forks can't read your repository's secrets, so the workflow run on this PR cannot publish to `community.develocity.cloud` even after you update the secret on the upstream repository.

If you want CI verification before merging, push the branch `dv/onboard-oss-community-develocity-instance` to a temporary branch on **this** repo (not the fork) and let the workflow run there — once the upstream secret has been updated, it will publish a Build Scan to `community.develocity.cloud`.

After merging, every CI run on this repository will publish a Build Scan to <https://community.develocity.cloud>.

## Required next step - provision local access keys

Build Scan publishing from local builds **will not work** until you provision access keys. Authenticated users can create an access key automatically by invoking:

```
./gradlew provisionDevelocityAccessKey
```