### PR TITLE
Test against Java 21 and Java 25 in CI

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ "21" ]
+        java-version: [ "21", "25" ]
         gradle-version: [ "8.6", "8.14.3", "9.0.0", "9.2.1" ]
     steps:
       - name: Check out project


### PR DESCRIPTION
## Summary
- Expand the GitHub Actions test matrix to run against both Java 21 and Java 25 (JDK 25 was already provisioned in the workflow steps but not exercised by the matrix).

## Test plan
- [ ] Verify the GitHub Actions run produces 8 matrix jobs (2 Java versions × 4 Gradle versions) and all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)