### PR TITLE
Bump Gradle Wrapper from 9.5.0 to 9.5.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=553c78f50dafcd54d65b9a444649057857469edf836431389695608536d6b746
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Bump Gradle Wrapper from 9.5.0 to 9.5.1.

Release notes of Gradle 9.5.1 can be found here:
https://docs.gradle.org/9.5.1/release-notes.html